### PR TITLE
Add retrievability guidelines to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,3 +135,16 @@ It's important to note that DataCap allocations are a one-time credit for a File
 ## Current status
 
 New applications are being accepted at this time, though please expect that the process will likely have some issues as we continue to test and improve the functionality of the process.
+
+## Retrieval Guidelines for Data Clients
+
+1. Data clients participating in the Fil+ program commit to ensuring the retrievability of open datasets through HTTP from their SPs.
+2. Fil+ data clients are advised to meticulously choose SPs that align with their specific data retrieval requirements.
+3. Fil+ clients can enhance their reputation by holding their SPs accountable for retrievability. This facilitates acquisition of additional DataCap from Notaries in the future.
+4. Fil+ Notaries consider the client’s track record on retrievability as part of their due diligence, and prioritize allocating DataCap to clients who actively engage in data retrieval.
+5. Multiple SPs can share a single unsealed copy of data with the same CID. This practice is deemed acceptable as it optimizes time and resource utilization.
+6. Data clients and SPs should be aware of the risk of network attacks, and mitigate these risks via rate limiting tools (e.g. set a max requests per second limit).
+7. Data clients and SPs should consider implementing a throttling limit that determines the maximum bandwidth a single retrieving client can consume at any given time.
+8. E Fil+ data clients storing private datasets should store with SPs that provide a level of retrievability consistent with the data clients’ retrieval needs indicated on the DataCap application.
+9. In the event of a large retrieval size, SPs should leverage tooling for load balancing to protect themselves.
+10. If the data client has very good (95-100%) retrievability track record via another retrieval method (GraphSync or BitSwap), then the data client might work with notaries to get future datacap approval on a case-by-case basis.

--- a/README.md
+++ b/README.md
@@ -138,13 +138,13 @@ New applications are being accepted at this time, though please expect that the 
 
 ## Retrieval Guidelines for Data Clients
 
-1. Data clients participating in the Fil+ program commit to ensuring the retrievability of open datasets by storing with SPs that serve HTTP retrievals with either [booster-http](https://boost.filecoin.io/http-retrieval/serving-files-with-booster-http) or their custom tooling.
-2. Fil+ data clients are advised to meticulously choose SPs that align with their specific data retrieval requirements.
-3. Fil+ clients can enhance their reputation by holding their SPs accountable for retrievability. This facilitates acquisition of additional DataCap from Notaries in the future.
-4. Fil+ Notaries consider the client’s track record on retrievability as part of their due diligence, and prioritize allocating DataCap to clients who store with SPs that serve reliable retrievals. 
-5. Multiple SPs can share a single unsealed copy of data with the same CID. This practice is deemed acceptable as it optimizes time and resource utilization.
-6. Data clients and SPs should be aware of the risk of network attacks, and mitigate these risks via rate limiting tools (e.g. set a max requests per second limit).
-7. Data clients and SPs should consider implementing a throttling limit that determines the maximum bandwidth a single retrieving client can consume at any given time.
-8. E Fil+ data clients storing private datasets should store with SPs that provide a level of retrievability consistent with the data clients’ retrieval needs indicated on the DataCap application.
-9. In the event of a large retrieval size, SPs should leverage tooling for load balancing to protect themselves.
-10. If the data client has very good (95-100%) retrievability track record via another retrieval method (GraphSync or BitSwap), then the data client might work with notaries to get future datacap approval on a case-by-case basis.
+1. Fil+ data clients are advised to meticulously choose SPs that align with their specific data retrieval requirements.
+2. Fil+ open dataset clients commit to ensuring the retrievability of open datasets by storing with SPs that serve HTTP retrievals with either [booster-http](https://boost.filecoin.io/http-retrieval/serving-files-with-booster-http) or their custom tooling.
+3. Fil+ clients can enhance their reputation by holding their SPs accountable for retrievability. This may streamline acquisition of additional DataCap in the future.
+4. Fil+ Notaries will consider the client’s track record on retrievability as part of their due diligence.
+5. Data clients and SPs should be aware of the risk of network attacks, and mitigate these risks via rate limiting tools (e.g. set a max requests per second limit).
+6. Data clients and SPs should consider implementing a throttling limit that determines the maximum bandwidth a single retrieving client can consume at any given time.
+7. Private data clients (E Fil+) should store with SPs that provide a level of retrievability consistent with the data clients’ retrieval needs indicated on the DataCap application.
+8. In the event of a large retrieval size, SPs should leverage tooling for load balancing to protect themselves.
+9. Multiple SPs can share a single unsealed copy of data with the same CID. This practice is deemed acceptable as it optimizes time and resource utilization.
+10. If the data client has very good (95-100%) retrievability track record via another retrieval method (GraphSync or BitSwap), then the data client may work with Notaries to get future DataCap approval on a case-by-case basis.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ In order for a client and their dataset to be eligible:
 
 - If a client wants to onboard more than 5+PiBs, the recommendation would be to start with a few applications and earn trust from the community. Having a positive reputation and proving to the community first by onboarding a smaller amount of data will help anyone who wants to onboard massive amounts of data much faster and smoother. 
 
-- Stored data should be readily retrievable on the network and this can be regularly verified (though the use of manual or automated verification that includes retrieving data from various miners over the course of the DataCap allocation timeframe). At this time all LDNs may have full retrievability, but it is not required. Each project should specify what portion of the data is retrievable and provide justification. From there notaries can decide during the due diligence phases if the client’s application is justifiable and can agree to sign it or not.
+- Stored data should be readily retrievable on the network and this can be regularly verified (though the use of manual or automated verification that includes retrieving data from various miners over the course of the DataCap allocation timeframe). Each project should specify what portion of the data is retrievable and provide justification. From there notaries can decide during the due diligence phases if the client’s application is justifiable and can agree to sign it or not.
 
 - There should be no open disputes in the Fil+ ecosystem against the client during the time that the application is open for review
 
@@ -138,10 +138,10 @@ New applications are being accepted at this time, though please expect that the 
 
 ## Retrieval Guidelines for Data Clients
 
-1. Data clients participating in the Fil+ program commit to ensuring the retrievability of open datasets through HTTP from their SPs.
+1. Data clients participating in the Fil+ program commit to ensuring the retrievability of open datasets by storing with SPs that serve HTTP retrievals with either [booster-http](https://boost.filecoin.io/http-retrieval/serving-files-with-booster-http) or their custom tooling.
 2. Fil+ data clients are advised to meticulously choose SPs that align with their specific data retrieval requirements.
 3. Fil+ clients can enhance their reputation by holding their SPs accountable for retrievability. This facilitates acquisition of additional DataCap from Notaries in the future.
-4. Fil+ Notaries consider the client’s track record on retrievability as part of their due diligence, and prioritize allocating DataCap to clients who actively engage in data retrieval.
+4. Fil+ Notaries consider the client’s track record on retrievability as part of their due diligence, and prioritize allocating DataCap to clients who store with SPs that serve reliable retrievals. 
 5. Multiple SPs can share a single unsealed copy of data with the same CID. This practice is deemed acceptable as it optimizes time and resource utilization.
 6. Data clients and SPs should be aware of the risk of network attacks, and mitigate these risks via rate limiting tools (e.g. set a max requests per second limit).
 7. Data clients and SPs should consider implementing a throttling limit that determines the maximum bandwidth a single retrieving client can consume at any given time.


### PR DESCRIPTION
Added retrievability guidelines to push for HTTP retrievals for open datasets stored with Fil+, with risk management advice and addressing caveats such as private datasets and graphsync & bitswap.